### PR TITLE
Convert configuration to @ConfigMapping

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -36,9 +36,6 @@
               <version>${quarkus.version}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -48,9 +48,6 @@
                             <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
-                    <compilerArgs>
-                        <arg>-AlegacyConfigRoot=true</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/runtime/src/main/java/io/quarkiverse/apistax/APIstaxConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/apistax/APIstaxConfiguration.java
@@ -1,19 +1,20 @@
 package io.quarkiverse.apistax;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "apistax", phase = ConfigPhase.RUN_TIME)
-public class APIstaxConfiguration {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.apistax")
+public interface APIstaxConfiguration {
 
     /**
      * The APIstax API key. Get one via https://apistax.io
      *
      * @asciidoclet
      */
-    @ConfigItem
-    public String apiKey;
+    String apiKey();
 
     /**
      * Enables the mock mode.
@@ -21,6 +22,6 @@ public class APIstaxConfiguration {
      *
      * @asciidoclet
      */
-    @ConfigItem(defaultValue = "false")
-    public Boolean mock;
+    @WithDefault("false")
+    Boolean mock();
 }

--- a/runtime/src/main/java/io/quarkiverse/apistax/APIstaxProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/apistax/APIstaxProducer.java
@@ -16,11 +16,11 @@ public class APIstaxProducer {
     @Produces
     @ApplicationScoped
     public APIstaxClient produceClient() {
-        if (configuration.mock) {
+        if (configuration.mock()) {
             return new APIstaxClientMock();
         } else {
             return new APIstaxClient.Builder()
-                    .apiKey(configuration.apiKey)
+                    .apiKey(configuration.apiKey())
                     .build();
         }
     }


### PR DESCRIPTION
We plan to retire the legacy config classes in a future version so let's move to @ConfigMapping.